### PR TITLE
Add php7.2-xdebug

### DIFF
--- a/scripts/install-php72
+++ b/scripts/install-php72
@@ -20,7 +20,8 @@ apt-get install -y \
     php7.2-mysql \
     php7.2-sqlite3 \
     php7.2-xml \
-    php7.2-zip
+    php7.2-zip \
+    php7.2-xdebug
 
 rm /etc/apt/sources.list.d/php.list
 sh /scripts/cleanup


### PR DESCRIPTION
Now that xdebug 2.6 is [released](https://github.com/xdebug/xdebug/releases) we can install php7.2-xdebug.