### PR TITLE
Update to debian stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker CI builds image with [Node], [PHP] and [Composer]
 
-This Docker image is based on the official node image which uses Debian Jessie.
+This Docker image is based on the official node 8 image which uses Debian Stretch.
 
 It is intended for running Continuous Integration and deployment builds for PHP applications with Node dependencies for compiling static assets. It also features [AWS cli] for interacting with AWS Services.
 

--- a/node-8-chrome.Dockerfile
+++ b/node-8-chrome.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8-stretch
 
 # Let the container know that there is no tty
 ENV DEBIAN_FRONTEND noninteractive

--- a/php-7.Dockerfile
+++ b/php-7.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8-stretch
 
 # Let the container know that there is no tty
 ENV DEBIAN_FRONTEND noninteractive

--- a/php-71.Dockerfile
+++ b/php-71.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8-stretch
 
 # Let the container know that there is no tty
 ENV DEBIAN_FRONTEND noninteractive

--- a/php-72.Dockerfile
+++ b/php-72.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8-stretch
 
 # Let the container know that there is no tty
 ENV DEBIAN_FRONTEND noninteractive

--- a/scripts/install-php7
+++ b/scripts/install-php7
@@ -3,8 +3,8 @@
 set -xe
 
 # Add sury repository
-echo "deb https://packages.sury.org/php/ jessie main" > /etc/apt/sources.list.d/php.list
-echo "deb-src https://packages.sury.org/php/ jessie main" >> /etc/apt/sources.list.d/php.list
+echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php.list
+echo "deb-src https://packages.sury.org/php/ stretch main" >> /etc/apt/sources.list.d/php.list
 wget -O- "https://packages.sury.org/php/apt.gpg" | apt-key add -
 
 # Install PHP 7 and its modules

--- a/scripts/install-php71
+++ b/scripts/install-php71
@@ -3,8 +3,8 @@
 set -xe
 
 # Add sury repository
-echo "deb https://packages.sury.org/php/ jessie main" > /etc/apt/sources.list.d/php.list
-echo "deb-src https://packages.sury.org/php/ jessie main" >> /etc/apt/sources.list.d/php.list
+echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php.list
+echo "deb-src https://packages.sury.org/php/ stretch main" >> /etc/apt/sources.list.d/php.list
 wget -O- "https://packages.sury.org/php/apt.gpg" | apt-key add -
 
 # Install PHP 7 and its modules

--- a/scripts/install-php72
+++ b/scripts/install-php72
@@ -3,8 +3,8 @@
 set -xe
 
 # Add sury repository
-echo "deb https://packages.sury.org/php/ jessie main" > /etc/apt/sources.list.d/php.list
-echo "deb-src https://packages.sury.org/php/ jessie main" >> /etc/apt/sources.list.d/php.list
+echo "deb https://packages.sury.org/php/ stretch main" > /etc/apt/sources.list.d/php.list
+echo "deb-src https://packages.sury.org/php/ stretch main" >> /etc/apt/sources.list.d/php.list
 wget -O- "https://packages.sury.org/php/apt.gpg" | apt-key add -
 
 # Install PHP 7 and its modules


### PR DESCRIPTION
Debian has dropped support for jessie, which is the default base image for `node:8`.
This means that any `apt-get update` commands will fail because the `jessie-updates` repository no longer exists.

The default base image for `node:9` and `node:10` is stretch, it's only `node:8` that's a problem. It looks like this will be updated pretty soon though, according to https://github.com/nodejs/docker-node/issues/1013.

I've manually built the three images using my changes and tested that they work fine. This shouldn't break anything, though I can't promise there won't be backwards incompatible changes if anyone using this image jessie specific features or repositories (though you should definitely not be doing this anymore since it's unsupported).